### PR TITLE
Feature 1/path testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # ansible-logrotate-plusplus
 Ansible role which installs and configures logrotate
+It can test if paths exist before writing a logrotate config to the server.
+Load the roles default vars with custom paths and per path parameters, and run the playbook across a dynamic
+infrastructure and only write logerotate rules to the appropriate system with the correct paths present.
+
+This project was based of https://github.com/arillso/ansible.logrotate 1.5.2
+(https://github.com/arillso/ansible.logrotate/commit/038649f7933c21ba9f1f2c8363bfb4d49aaf46f2)
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,49 @@
+---
+# List of global options. If this is empty the default options of the
+# distribution are used.
+logrotate_options: []
+
+# Path to the include files
+logrotate_include_dir: /etc/logrotate.d
+
+# package name to install logrotate.
+logrotate_package: logrotate
+
+# Enable hourly rotation with cron.
+logrotate_use_hourly_rotation: false
+
+# logroate for wtmp
+logrotate_wtmp:
+  logs:
+    - /var/log/wtmp
+  options:
+    - missingok
+    - monthly
+    - create 0664 root utmp
+    - rotate 1
+
+# logroate for btmp
+logrotate_btmp:
+  logs:
+    - /var/log/btmp
+  options:
+    - missingok
+    - monthly
+    - create 0660 root utmp
+    - rotate 1
+
+# More log files can be added that will log rotate.
+# An example of multiple log rotate applications with available settings:
+# logrotate_applications:
+#   - name: name-your-log-rotate-application
+#     definitions:
+#       - logs:
+#           - /var/log/apt/term.log
+#           - /var/log/apt/history.log
+#         options:
+#           - rotate 12
+#           - monthly
+#           - missingok
+#           - notifempty
+#           - compress
+logrotate_applications: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,14 +36,50 @@ logrotate_btmp:
 # An example of multiple log rotate applications with available settings:
 # logrotate_applications:
 #   - name: name-your-log-rotate-application
-#     definitions:
-#       - logs:
-#           - /var/log/apt/term.log
-#           - /var/log/apt/history.log
-#         options:
-#           - rotate 12
-#           - monthly
-#           - missingok
-#           - notifempty
-#           - compress
-logrotate_applications: []
+#     logs:
+#       - /var/log/apt/term.log
+#       - /var/log/apt/history.log
+#     options:
+#       - rotate 12
+#       - monthly
+#       - missingok
+#       - notifempty
+#       - compress
+logrotate_applications:
+  - name: nextcloud-snap-apache-php_errors
+    logs:
+      - /var/snap/nextcloud/current/apache/logs/*.log
+    options:
+      - daily
+      - compress
+      - rotate 6
+      - missingok
+      - copytruncate
+      - delaycompress
+
+  - name: nextcloud-snap-apache-error_log"
+    logs:
+      - /var/snap/nextcloud/current/apache/logs/error_log
+    options:
+      - daily
+      - compress
+      - rotate 6
+      - missingok
+      - copytruncate
+      - delaycompress
+
+  - name: custom
+    logs:
+      -  /var/log/custom/*_log
+    options:
+      - daily
+      - compress
+      - rotate 6
+
+  - name : dpkg
+    logs:
+      - /var/log/dpkg.log
+    options:
+      - daily
+      - compress
+      - rotate 6

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,32 @@
+---
+galaxy_info:
+  author: 'stationgroup'
+  description: |
+    Ansible role for installings and configuring lograte on Linux, deploying a list of defaults only if the
+    logfiles are present on the system.
+  license: MIT
+  min_ansible_version: 2.8
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+    - name: Fedora
+      versions:
+        - 29
+    - name: Ubuntu
+      versions:
+        - bionic
+        - cosmic
+        - disco
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+        - buster
+
+  galaxy_tags:
+    - system
+    - logrotate
+    - log
+    - rotate

--- a/tasks/create-logrotate-application-configuration-files.yml
+++ b/tasks/create-logrotate-application-configuration-files.yml
@@ -1,0 +1,22 @@
+---
+- name: 'check if there exist log files for {{ item.name }}'
+  shell:
+    cmd: "ls -l {{ item.logs|join(' ') }}"
+  changed_when: false
+  register: _available_logs
+  check_mode: false
+  failed_when: false
+  tags:
+    - configuration
+
+- name: 'create logrotate configuration file for {{ item.name }}'
+  become: true
+  template:
+    src: 'etc/logrotate.d/application.j2'
+    dest: '/etc/logrotate.d/{{ item.name }}'
+    owner: root
+    group: root
+    mode: 0644
+  when: _available_logs.stdout_lines|length() > 0
+  tags:
+    - configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,15 +44,10 @@
     - configuration
 
 - name: 'create logrotate application configuration files'
-  become: true
-  template:
-    src: 'etc/logrotate.d/application.j2'
-    dest: '/etc/logrotate.d/{{ item.name }}'
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - '{{ logrotate_applications }}'
+  include_tasks: create-logrotate-application-configuration-files.yml
+  loop: '{{ logrotate_applications }}'
+  loop_control:
+    label: "{{ item.name }}"
   tags:
     - configuration
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: add OS specific variables
+  include_vars: '{{ loop_vars }}'
+  with_first_found:
+    - files:
+        - '{{ distribution }}-{{ distribution_version }}.yml'
+        - '{{ distribution }}-{{ distribution_major_version }}.yml'
+        - '{{ distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
+        - '{{ ansible_system }}.yml'
+        - 'defaults.yml'
+      paths:
+        - 'vars'
+  loop_control:
+    loop_var: loop_vars
+  vars:
+    distribution: '{{ ansible_distribution }}'
+    distribution_version: '{{ ansible_distribution_version }}'
+    distribution_major_version: '{{ ansible_distribution_major_version }}'
+  tags:
+    - configuration
+    - packages
+
+- name: 'install logrotate packages'
+  become: true
+  package:
+    name: '{{ logrotate_package }}'
+    state: present
+  register: register_install_package
+  until: register_install_package is succeeded
+  retries: 3
+  tags:
+    - packages
+
+- name: 'create logrotate configuration file'
+  become: true
+  template:
+    src: 'etc/logrotate.conf.j2'
+    dest: '/etc/logrotate.conf'
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - configuration
+
+- name: 'create logrotate application configuration files'
+  become: true
+  template:
+    src: 'etc/logrotate.d/application.j2'
+    dest: '/etc/logrotate.d/{{ item.name }}'
+    owner: root
+    group: root
+    mode: 0644
+  with_items:
+    - '{{ logrotate_applications }}'
+  tags:
+    - configuration
+
+- name: Symlink for hourly rotation
+  file:
+    path: "/etc/cron.hourly/logrotate"
+    src: "/etc/cron.daily/logrotate"
+    state: "{{ 'link' if logrotate_use_hourly_rotation else 'absent' }}"

--- a/templates/etc/logrotate.conf.j2
+++ b/templates/etc/logrotate.conf.j2
@@ -1,0 +1,30 @@
+{{ ansible_managed | comment }}
+
+# see "man logrotate" for details
+{% if logrotate_options | length > 0 %}
+{% for option in logrotate_options %}
+{{ option }}
+{% endfor %}
+{% else %}
+{% for option in logrotate_distribution_options | default([]) %}
+{{ option }}
+{% endfor %}
+{% endif %}
+
+# packages drop log rotation information into this directory
+include {{ logrotate_include_dir }}
+
+# no packages own wtmp, or btmp -- we'll rotate them here
+{{ logrotate_wtmp.logs | join(" ") }} {
+{% for option in logrotate_wtmp.options %}
+    {{ option }}
+{% endfor %}
+}
+
+{{ logrotate_btmp.logs | join(" ") }} {
+{% for option in logrotate_btmp.options %}
+    {{ option }}
+{% endfor %}
+}
+
+# system-specific logs may be configured here

--- a/templates/etc/logrotate.d/application.j2
+++ b/templates/etc/logrotate.d/application.j2
@@ -1,0 +1,37 @@
+{{ ansible_managed | comment }}
+
+{% for definition in item.definitions %}
+{{ definition.logs | join(" ") }} {
+{% for option in definition.options %}
+    {{ option }}
+{% endfor %}
+{% if definition.postrotate|default([]) %}
+    postrotate
+{% for line in definition.postrotate %}
+        {{ line }}
+{% endfor %}
+    endscript
+{% endif %}
+{% if definition.preremove|default([]) %}
+    preremove
+{% for line in definition.preremove %}
+        {{ line }}
+{% endfor %}
+    endscript
+{% endif %}
+{% if definition.lastaction|default([]) %}
+    lastaction
+{% for line in definition.lastaction %}
+        {{ line }}
+{% endfor %}
+    endscript
+{% endif %}
+{% if definition.firstaction|default([]) %}
+    firstaction
+{% for line in definition.firstaction %}
+        {{ line }}
+{% endfor %}
+    endscript
+{% endif %}
+}
+{% endfor %}

--- a/templates/etc/logrotate.d/application.j2
+++ b/templates/etc/logrotate.d/application.j2
@@ -1,37 +1,35 @@
 {{ ansible_managed | comment }}
 
-{% for definition in item.definitions %}
-{{ definition.logs | join(" ") }} {
-{% for option in definition.options %}
+{{ item.logs | join(" ") }} {
+{% for option in item.options %}
     {{ option }}
 {% endfor %}
-{% if definition.postrotate|default([]) %}
+{% if item.postrotate|default([]) %}
     postrotate
-{% for line in definition.postrotate %}
+{% for line in item.postrotate %}
         {{ line }}
 {% endfor %}
     endscript
 {% endif %}
-{% if definition.preremove|default([]) %}
+{% if item.preremove|default([]) %}
     preremove
-{% for line in definition.preremove %}
+{% for line in item.preremove %}
         {{ line }}
 {% endfor %}
     endscript
 {% endif %}
-{% if definition.lastaction|default([]) %}
+{% if item.lastaction|default([]) %}
     lastaction
-{% for line in definition.lastaction %}
+{% for line in item.lastaction %}
         {{ line }}
 {% endfor %}
     endscript
 {% endif %}
-{% if definition.firstaction|default([]) %}
+{% if item.firstaction|default([]) %}
     firstaction
-{% for line in definition.firstaction %}
+{% for line in item.firstaction %}
         {{ line }}
 {% endfor %}
     endscript
 {% endif %}
 }
-{% endfor %}

--- a/vars/CentOS.yml
+++ b/vars/CentOS.yml
@@ -1,0 +1,9 @@
+---
+# vars file for arillso.logrotate
+
+# List of global options for the different systems.
+logrotate_distribution_options:
+  - weekly
+  - rotate 4
+  - create
+  - dateext

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,9 @@
+---
+# vars file for arillso.logrotate
+
+# List of global options for the different systems.
+logrotate_distribution_options:
+  - weekly
+  - rotate 4
+  - create
+  - dateext

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,9 @@
+---
+# vars file for arillso.logrotate
+
+# List of global options for the different systems.
+logrotate_distribution_options:
+  - weekly
+  - rotate 4
+  - create
+  - dateext

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,10 @@
+---
+# vars file for arillso.logrotate
+
+# List of global options for the different systems.
+logrotate_distribution_options:
+  - weekly
+  - rotate 4
+  - create
+  - dateext
+  - su root syslog


### PR DESCRIPTION
Ansible role which installs and configures logrotate, based of https://github.com/arillso/ansible.logrotate 1.5.2

An additional patch allows a logrotate role to test if paths exist before writing a logrotate config to the server.
Load the roles default vars with custom paths and per path parameters, and run the playbook across a dynamic
infrastructure and only write logrotate rules to the appropriate system with the correct paths present.